### PR TITLE
Actualizer should grab default image and no plugins

### DIFF
--- a/lib/deployments/gateway.js
+++ b/lib/deployments/gateway.js
@@ -4,7 +4,7 @@ const debug = require('debug')('actualizer:gateway');
 slug.defaults.mode = 'rfc3986';
 
 const GATEWAY_IMAGE = process.env.GATEWAY_IMAGE || '410240865662.dkr.ecr.us-west-2.amazonaws.com/expressgateway/express-gateway';
-const GATEWAY_VERSION = process.env.GATEWAY_VERSION || 'metrics';
+const GATEWAY_VERSION = process.env.GATEWAY_VERSION || 'latest';
 const ADMIN_CROSS_ORIGIN = process.env.ADMIN_CROSS_ORIGIN || '*';
 
 const defaultSystemConfig = {
@@ -16,11 +16,6 @@ const defaultSystemConfig = {
       password: '${REDIS_PASSWORD}',
       namespace: '${EG_NAMESPACE}'
       /* eslint-enable no-template-curly-in-string */
-    }
-  },
-  plugins: {
-    cAdvisor: {
-      package: '/usr/src/app/plg/index.js'
     }
   },
   crypto: {


### PR DESCRIPTION
Actualizer, by default, should not pick any particular Docker image as well as not install any plugin by default. Instead, we should create proper docker images as well as provide per-gateway `system.config` files for that.

Connect #37 
Closes #37  